### PR TITLE
feat: Add --allow-untrusted to apk add.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV BASE_URL="https://get.helm.sh"
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.4.2-linux-amd64.tar.gz"
 
-RUN apk add --no-cache build-base ca-certificates \
+RUN apk add --allow-untrusted --no-cache build-base ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
     jq curl bash nodejs aws-cli && \
     # Install helm version 2:


### PR DESCRIPTION
enable untrusted to apk add.

error when install aws-cli (blocking env deploys):

![Screenshot from 2022-07-14 19-39-31](https://user-images.githubusercontent.com/83827894/179100167-c3a25bda-f7cc-4e01-9d77-42fbf973acc7.png)
