### PR TITLE
DEVOPS-1134: remove option `--set=app.name=${appName}`

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ async function run() {
     }
 
     if (dryRun) args.push("--dry-run");
-    if (appName) args.push(`--set=app.name=${appName}`);
+    // if (appName) args.push(`--set=app.name=${appName}`);
     if (version) args.push(`--set=app.version=${version}`);
     if (chartVersion) args.push(`--version=${chartVersion}`);
     if (timeout) args.push(`--timeout=${timeout}`);


### PR DESCRIPTION
Essa alteração é necessária caso formos utilizar o chart [app-stack](https://github.com/avenuesec/helm-charts-devops/tree/main/charts/app-stack) do repo `helm-charts-devops`.
